### PR TITLE
docs: pkg upgrade & install wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Run these commands:
 ```sh
 termux-setup-storage
 pkg update
-pkg install python3 aria2 ffmpeg jq termux-api
+pkg upgrade
+pkg install python3 aria2 ffmpeg jq termux-api wget
 pip install --upgrade yt-dlp
 mkdir ~/bin
 wget https://github.com/kairusds/termux-url-opener/raw/master/termux-url-opener -P ~/bin


### PR DESCRIPTION
This fixes 2 errors I ran into, where 1. pip complained about missing SSL support and 2. wget wasn't installed